### PR TITLE
fix: remove newlines before wget

### DIFF
--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -9,7 +9,7 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
     echo "Adding repositories"
     for REPO in "${REPOS[@]}"; do
         REPO="${REPO//%OS_VERSION%/${OS_VERSION}}"
-        wget "${REPO}" -P "/etc/yum.repos.d/"
+        wget "${REPO//[$'\t\r\n ']}" -P "/etc/yum.repos.d/"
     done
 fi
 


### PR DESCRIPTION
including the newlines causes filenames to be postfixed with %0A and thus the repo files to not work

this commit uses the same bashism as above line to remove newlines from the $REPO var before using it in the wget command