### PR TITLE
fix: bling justfile installer nested just dir

### DIFF
--- a/modules/bling/installers/justfiles.sh
+++ b/modules/bling/installers/justfiles.sh
@@ -3,4 +3,4 @@
 # Tell build process to exit if there are any errors.
 set -oue pipefail
 
-cp -r "$BLING_DIRECTORY/files/usr/share/ublue-os/just" "/usr/share/ublue-os/just"
+cp -r "$BLING_DIRECTORY/files/usr/share/ublue-os/just/*" "/usr/share/ublue-os/just"


### PR DESCRIPTION
idon't create another just directory inside the basic just directory, just copy the contents